### PR TITLE
feat: added API delete user (by id)

### DIFF
--- a/packages/backend/src/controllers/UserController.ts
+++ b/packages/backend/src/controllers/UserController.ts
@@ -40,6 +40,21 @@ class UserController {
 
     return response.json(user)
   }
+
+  async remove(request: Request, response: Response) {
+    const { userId } = request.params
+
+    const userRepository = getCustomRepository(UserRepository)
+
+    const { affected = 0 } = await userRepository.delete(userId)
+
+    if (!affected) {
+      const resError = { error: `user wit id '${userId}' was not found` }
+      return response.status(404).json(resError)
+    }
+
+    return response.status(204)
+  }
 }
 
 export default new UserController()

--- a/packages/backend/src/routes/users.routes.ts
+++ b/packages/backend/src/routes/users.routes.ts
@@ -6,5 +6,6 @@ const router = Router()
 router.post('/', UserController.create)
 router.get('/', UserController.index)
 router.get('/:userId', UserController.view)
+router.delete('/:userId', UserController.remove)
 
 export default router


### PR DESCRIPTION
Tentativa de fechar a issue #10

A ideia é retornar `204` -- sobre um `DELETE /users/{user_id}` -- se a operação foi realizada. E `404 { error }` se o usuário não foi encontrado, mas sem executar duas consultas no BD :smile: 